### PR TITLE
Write test results even for skipped scenarios

### DIFF
--- a/src/main/java/org/whipper/Whipper.java
+++ b/src/main/java/org/whipper/Whipper.java
@@ -184,12 +184,12 @@ public class Whipper {
                         throw ex;
                     } finally {
                         scen.after();
-                        for(TestResultsWriter trw : trws){
-                            trw.writeResultOfScenario(scen);
-                        }
                     }
                 } else {
                     LOG.warn("Skipping scenario {}.", scen.getId());
+                }
+                for(TestResultsWriter trw : trws){
+                    trw.writeResultOfScenario(scen);
                 }
             }
         } finally {


### PR DESCRIPTION
Moved the test result writing code so that it is called even for
scenarios that failed to initialize. It is up to the TestResultsWriter
to decide how to deal with initialization failures.