### PR TITLE
fix regex type name comparison

### DIFF
--- a/whipper/src/main/java/org/whipper/ExpectedResultHolder.java
+++ b/whipper/src/main/java/org/whipper/ExpectedResultHolder.java
@@ -7,7 +7,6 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.whipper.xml.XmlHelper;
@@ -236,7 +235,7 @@ public class ExpectedResultHolder {
                         addError("Expected and actual column label are different. Expected:["
                                 + columnLabels.get(i) + "], actual: [" + labels.get(i) + "].");
                     }
-                    if(!columnTypeNames.get(i).equalsIgnoreCase(types.get(i))){
+                    if (!isMatchingColumnType(types.get(i), columnTypeNames.get(i))) {
                         addError("Expected and actual column type are different. Expected:["
                                 + columnTypeNames.get(i) + "], actual: [" + types.get(i) + "].");
                     }
@@ -254,6 +253,23 @@ public class ExpectedResultHolder {
                 }
             }
         }
+    }
+
+    /**
+     * Method that decides if the two types are matching or not.
+     * Criteria:
+     * 1. the types are equal
+     * 2. actualType is {@link XmlHelper#TYPE_STRING} and expected type is {@link XmlHelper#TYPE_REGEX}
+     *
+     * @param actualType
+     *            string with type name
+     * @param expectedType
+     *            string with type name
+     * @return true if any of the Criteria above matches.
+     */
+    private boolean isMatchingColumnType(String actualType, String expectedType) {
+        return expectedType.equalsIgnoreCase(actualType) || (actualType.equalsIgnoreCase(XmlHelper.TYPE_STRING)
+                && expectedType.equalsIgnoreCase(XmlHelper.TYPE_REGEX));
     }
 
     /**

--- a/whipper/src/main/java/org/whipper/xml/XmlHelper.java
+++ b/whipper/src/main/java/org/whipper/xml/XmlHelper.java
@@ -65,21 +65,22 @@ public class XmlHelper {
     /* XML 1.0 valid characters - #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF] */
     private static final Pattern INVALID_XML_1_0_TEXT = Pattern.compile(".*[^\u0009\r\n\u0020-\uD7FF\uE000-\uFFFD\ud800\udc00-\udbff\udfff].*");
     /* XML tags */
-    private static final String TYPE_INTEGER = "integer";
-    private static final String TYPE_FLOAT = "float";
-    private static final String TYPE_LONG = "long";
-    private static final String TYPE_DOUBLE = "double";
-    private static final String TYPE_BYTE = "byte";
-    private static final String TYPE_DATE = "date";
-    private static final String TYPE_TIME = "time";
-    private static final String TYPE_TIMESTAMP = "timestamp";
-    private static final String TYPE_BOOLEAN = "boolean";
-    private static final String TYPE_CHAR = "char";
-    private static final String TYPE_SHORT = "short";
-    private static final String TYPE_BIGINTEGER = "biginteger";
-    private static final String TYPE_BIGDECIMAL = "bigdecimal";
-    private static final String TYPE_UNPRINTABLE = "unprintable";
-    private static final String TYPE_REGEX = "regex";
+    public static final String TYPE_INTEGER = "integer";
+    public static final String TYPE_FLOAT = "float";
+    public static final String TYPE_LONG = "long";
+    public static final String TYPE_DOUBLE = "double";
+    public static final String TYPE_BYTE = "byte";
+    public static final String TYPE_DATE = "date";
+    public static final String TYPE_TIME = "time";
+    public static final String TYPE_TIMESTAMP = "timestamp";
+    public static final String TYPE_BOOLEAN = "boolean";
+    public static final String TYPE_CHAR = "char";
+    public static final String TYPE_SHORT = "short";
+    public static final String TYPE_BIGINTEGER = "biginteger";
+    public static final String TYPE_BIGDECIMAL = "bigdecimal";
+    public static final String TYPE_UNPRINTABLE = "unprintable";
+    public static final String TYPE_REGEX = "regex";
+    public static final String TYPE_STRING = "string";
     /* XML I/O */
     private static final Unmarshaller RESULT_UNMARSHALLER;
     private static final Unmarshaller SUITE_UNMARSHALLER;

--- a/whipper/src/test/java/org/whipper/ExpectedResultHolderTest.java
+++ b/whipper/src/test/java/org/whipper/ExpectedResultHolderTest.java
@@ -99,7 +99,7 @@ public class ExpectedResultHolderTest{
         Assertions
             .assertAll(
                 () -> Assertions.assertTrue(exp.equals(
-                    getMockTable(Collections.singletonList("regex"), Collections.singletonList("regex"),
+                    getMockTable(Collections.singletonList("string"), Collections.singletonList("regex"),
                         Arrays.asList(Collections.singletonList(24.00000000), Collections.singletonList("TRUE"))),
                     false, BigDecimal.ZERO), "Table exp - table act - regex should match"),
                 () -> Assertions


### PR DESCRIPTION
So far (see the fixed unit test) the type name comparison was done as string equality. With addition of regex type, we need to allow matching actual result type 'string' to expected result type 'regex'.